### PR TITLE
Added access of contact page from about page

### DIFF
--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -470,7 +470,7 @@
             <li><a href="#" class="footer-link">About us</a></li>
             <li><a href="#" class="footer-link">Pricing plans</a></li>
             <li><a href="../index.html#blog" class="footer-link">Our blog</a></li>
-            <li><a href="#" class="footer-link">Contacts</a></li>
+            <li><a href="../../ContactUs.html" class="footer-link">Contacts</a></li>
           </ul>
           <ul class="footer-list">
             <li><p class="footer-list-title">Support</p></li>


### PR DESCRIPTION
# Pull Request Template for Vehigo
Please fill out the following sections to help us review your pull request efficiently.

## 1. Title
Added access of contact page from about page.

## 2. Description
Earlier when we were in About us page, and click on the contact link in the footer section, it takes us nowhere. But now as link to contact page is added, now it takes us to contact page.

## 3. Related Issues
fixed #114 

## 4. Changes Made
Link to the contact page is now added.

## 5. Checklist
Before submitting, please ensure you have completed the following:

- [x] I have read the project's contributing guidelines.
- [x] My code follows the project's coding style and conventions.
- [x] I have performed a thorough self-review of my own code.
- [x] I have added comments to my code, especially in complex or non-obvious sections.
- [ ] I have made corresponding updates to the documentation (e.g., README, API docs) if my changes require it.
- [x] My changes introduce no new warnings or errors during compilation/runtime.
- [x] I have added new tests or updated existing ones to cover my changes, and they pass locally.
- [x] Any dependent changes (e.g., API updates, library versions) have been addressed.

##Screenshot
Now after going to contact in about us page, it shows this page

<img width="1365" height="595" alt="image" src="https://github.com/user-attachments/assets/61e756af-2fa0-426e-8e97-48803103f978" />

