### PR TITLE
fix(CSS): Correct footer column alignment-126

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1680,7 +1680,7 @@ body.dark-mode footer {
   }
 
   .footer-list:last-of-type {
-    width: 50%;
+    width: 17.33%;
   }
 }
 
@@ -1841,7 +1841,7 @@ body.dark-mode footer {
   }
 
   .footer-list:last-of-type {
-    width: 33.33%;
+    width: 15.33%;
   }
 }
 


### PR DESCRIPTION
## 1. Title
fix(CSS): Correct footer column alignment
## 2. Description
This pull request resolves a UI bug where the columns in the site footer were visually misaligned. The issue was most noticeable with the last column, which was taking up an incorrect amount of space, causing an unbalanced layout.
This fix directly adjusts the CSS width percentages for the final footer column in both the default and dark-mode stylesheets to ensure all footer content is visually aligned and appears evenly spaced.
## 3. Related Issues
Fixes #126
## 4. Changes Made
[x] Modified the width of .footer-list:last-of-type from 50% to 17.33% in the main stylesheet.
[x] Adjusted the width of the same element from 33.33% to 15.33% in the dark-mode styles to match the alignment.
## 6. Screenshots/GIFs
Before: Large Desktop 
<img width="1440" height="900" alt="Screenshot 2025-07-27 at 10 02 23 AM" src="https://github.com/user-attachments/assets/6f0e7122-705e-4947-b91b-23a1a27d96e4" />

After: Large Desktop 
<img width="1552" height="1012" alt="Screenshot 2025-07-28 at 7 20 10 AM" src="https://github.com/user-attachments/assets/5d44d84b-06b6-477a-baca-f009eaef2ab0" />

Before: Tablet
<img width="2288" height="1760" alt="Screenshot 2025-07-28 at 8 00 58 AM" src="https://github.com/user-attachments/assets/e3de6716-fbb7-4659-904f-81510912d0ed" />

After: Tablet
<img width="1295" height="1012" alt="Screenshot 2025-07-28 at 7 19 54 AM" src="https://github.com/user-attachments/assets/99a0f69a-519b-4034-9e08-926cc7a7407a" />

Before: Mobile
<img width="1224" height="1760" alt="Screenshot 2025-07-28 at 8 03 24 AM" src="https://github.com/user-attachments/assets/528a5b3f-477b-47f4-9f38-b565c8b25111" />

After: Mobile
<img width="1224" height="1760" alt="Screenshot 2025-07-28 at 8 03 42 AM" src="https://github.com/user-attachments/assets/345f8ffc-a780-4a0c-a1b7-8f2bbdae0de5" />




