### PR TITLE
Fixed Navbar Links of offline.html

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -41,19 +41,19 @@
       <nav class="navbar" data-navbar>
         <ul class="navbar-list">
           <li>
-            <a href="index.html" class="navbar-link" data-nav-link>Home</a>
+            <a href="src/index.html" class="navbar-link" data-nav-link>Home</a>
           </li>
 
           <li>
-            <a href="#featured-car" class="navbar-link" data-nav-link>Explore cars</a>
+            <a href="featured-car.html" class="navbar-link" data-nav-link>Explore cars</a>
           </li>
 
           <li>
-            <a href="#" class="navbar-link" data-nav-link>About us</a>
+            <a href="src/pages/about.html" class="navbar-link" data-nav-link>About us</a>
           </li>
 
           <li>
-            <a href="#blog" class="navbar-link" data-nav-link>Blog</a>
+            <a href="blog.html" class="navbar-link" data-nav-link>Blog</a>
           </li>
 
           <li>


### PR DESCRIPTION
Fixed the following Navbar Links of offline.html :

1. Index was opening wrong Index Page.
2. Featured cars page linked.
3. About Us page linked.
4.  Blog page linked.

<img width="1909" height="920" alt="Screenshot 2025-08-05 143345" src="https://github.com/user-attachments/assets/275fc2ae-6e60-45c8-989b-45f5cf4489d8" />
