### PR TITLE
Fixed the Links in T&C page and Footer Sections of Home page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -869,7 +869,7 @@
           </li>
 
           <li>
-            <a href="#" class="footer-link">About us</a>
+            <a href="/src/pages/about.html" class="footer-link">About us</a>
           </li>
 
           <li>
@@ -877,11 +877,11 @@
           </li>
 
           <li>
-            <a href="#" class="footer-link">Our blog</a>
+            <a href="../blog.html" class="footer-link">Our blog</a>
           </li>
 
           <li>
-            <a href="#" class="footer-link">Contacts</a>
+            <a href="../ContactUs.html" class="footer-link">Contacts</a>
           </li>
 
         </ul>
@@ -905,7 +905,7 @@
           </li>
 
           <li>
-            <a href="#" class="footer-link">Terms & conditions</a>
+            <a href="../tandc.html" class="footer-link">Terms & conditions</a>
           </li>
 
         </ul>

--- a/tandc.html
+++ b/tandc.html
@@ -34,19 +34,19 @@
             <ul class="navbar-list">
     
               <li>
-                <a href="/index.html" class="navbar-link" data-nav-link>Home</a>
+                <a href="src/index.html" class="navbar-link" data-nav-link>Home</a>
               </li>
     
               <li>
-                <a href="/#featured-car" class="navbar-link" data-nav-link>Explore cars</a>
+                <a href="featured-car.html" class="navbar-link" data-nav-link>Explore cars</a>
               </li>
     
               <li>
-                <a href="/index.html" class="navbar-link" data-nav-link>About us</a>
+                <a href="src/pages/about.html" class="navbar-link" data-nav-link>About us</a>
               </li>
     
               <li>
-                <a href="/#blog" class="navbar-link" data-nav-link>Blog</a>
+                <a href="blog.html" class="navbar-link" data-nav-link>Blog</a>
               </li>
     
             </ul>


### PR DESCRIPTION
Fixed the Links in T&C page and Footer Sections of Home page :

1) Fixed the Wrong link of Home Page, in T&C navbar.
2) Fixed the non-linking of Explore page, in T&C navbar.
3) Fixed the non-linking of About Us page, in T&C navbar.
4) Fixed the non-linking of Blog page, in T&C navbar.

5) Fixed the non-linking of T&C page, in Footer section of Home page.
6) Fixed the non-linking of Contact Us page, in Footer section of Home page.
7) Fixed the non-linking of Blog page, in Footer section of Home page.
8) Fixed the non-linking of About Us page in Footer section of Home page.

<img width="1917" height="518" alt="Screenshot 2025-08-05 172425" src="https://github.com/user-attachments/assets/643b34e7-44ef-4b99-a72d-97704dba4e16" />


<img width="1903" height="474" alt="Screenshot 2025-08-05 172352" src="https://github.com/user-attachments/assets/6009d2dc-080c-449c-9300-d84458a43399" />
