### PR TITLE
Added dynamic year functionality to footer on HTML pages

### DIFF
--- a/ContactUs.html
+++ b/ContactUs.html
@@ -260,7 +260,7 @@
           </ul>
 
           <p class="copyright">
-            &copy; 2023 <a href="#">VehiGo</a> Contact us through
+            &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
           </p>
         </div>
       </div>
@@ -301,3 +301,7 @@
 </a>
 
 </body>
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>

--- a/accountpage.html
+++ b/accountpage.html
@@ -489,7 +489,7 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
@@ -504,6 +504,10 @@
   <!-- 
     - custom js link
   -->
+    <script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
   <script src="./assets/js/script.js"></script>
 
   <!-- 

--- a/carPage.html
+++ b/carPage.html
@@ -363,15 +363,19 @@
                 </ul>
 
                 <p class="copyright">
-                    &copy; 2023 <a href="#">VehiGo</a> Contact us through
+                    &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
                 </p>
 
             </div>
 
         </div>
     </footer>
+    
 </body>
-
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
 <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
 <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
 

--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -297,10 +297,14 @@
       </ul>
 
       <p class="copyright">
-        &copy; 2023 <a href="#">VehiGo</a> Contact us through
+        &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
       </p>
     </div>
   </div>
 </footer>
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
 <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
 <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -1295,7 +1295,7 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
@@ -1309,6 +1309,13 @@
   <!-- 
     - custom js link
   -->
+
+    <script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
+
+
   <script src="./assets/js/script.js"></script>
 
   <!-- 

--- a/src/pages/accountpage.html
+++ b/src/pages/accountpage.html
@@ -491,7 +491,7 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
@@ -506,6 +506,10 @@
   <!-- 
     - custom js link
   -->
+    <script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
   <script src="../assets/js/script.js"></script>
 
   <!-- 

--- a/src/pages/bill.html
+++ b/src/pages/bill.html
@@ -431,12 +431,17 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
 
     </div>
   </footer>
+  
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
 
 </html>

--- a/src/pages/carPage.html
+++ b/src/pages/carPage.html
@@ -379,7 +379,7 @@
                 </ul>
 
                 <p class="copyright">
-                    &copy; 2023 <a href="#">VehiGo</a> Contact us through
+                    &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
                 </p>
 
             </div>
@@ -387,6 +387,11 @@
         </div>
     </footer>
 </body>
+
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
 
 <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
 <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>

--- a/src/pages/trackPage.html
+++ b/src/pages/trackPage.html
@@ -268,7 +268,7 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
@@ -276,6 +276,11 @@
     </div>
   </footer>
 </body>
+
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
 
 <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
 <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>

--- a/trackPage.html
+++ b/trackPage.html
@@ -257,15 +257,19 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
 
     </div>
   </footer>
-</body>
 
+</body>
+<script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
 <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
 <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
 

--- a/vehigo-backend/accountpage.html
+++ b/vehigo-backend/accountpage.html
@@ -472,7 +472,7 @@
         </ul>
 
         <p class="copyright">
-          &copy; 2023 <a href="#">VehiGo</a> Contact us through
+          &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> Contact us through
         </p>
 
       </div>
@@ -487,6 +487,11 @@
   <!-- 
     - custom js link
   -->
+    <script>
+  const yearEl = document.getElementById('copyright-year');
+  if(yearEl) yearEl.textContent = new Date().getFullYear();
+</script>
+
   <script src="./assets/js/script.js"></script>
 
   <!-- 


### PR DESCRIPTION
# Pull Request Template for Vehigo

## 1. Title
fix: Replace hardcoded 2023 with dynamic current year in footer

## 2. Description
This pull request updates the Vehigo footer to display the current year dynamically instead of a hardcoded "2023". Previously, the footer always showed "2023", requiring manual updates each year.  

The change involves:
- Replacing the hardcoded year with a `<span>` element having `id="copyright-year"`.
- Adding a small JavaScript snippet that sets the text content of this span to the current year using `new Date().getFullYear()`.  

This ensures that the footer always shows the correct year automatically, improving maintainability and keeping the site up-to-date without manual intervention.

## 3. Related Issues
Closes #354

## 4. Changes Made
- [x] Replaced hardcoded `2023` in the footer with `<span id="copyright-year"></span>`.
- [x] Added the following internal script:
```html
<script>
  const yearEl = document.getElementById('copyright-year');
  if(yearEl) yearEl.textContent = new Date().getFullYear();
</script>
