### PR TITLE
Fixed Home page Hover bug

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -290,7 +290,7 @@
   .featured-car-card:hover {
     transform: translateY(-8px) scale(1.02);
     box-shadow: 0 20px 30px rgba(0, 123, 255, 0.15);
-    z-index: 10;
+    z-index: 1;
   }
   
   .featured-car-card::before {


### PR DESCRIPTION
Fixed Home page Hover bug.
The Feature Card use to Come above the Navbar on Hover.

Before : 
<img width="1884" height="599" alt="Screenshot 2025-09-05 145636" src="https://github.com/user-attachments/assets/c77d6da7-0dbd-4c17-af09-4497d73e44aa" />
<img width="1708" height="760" alt="Screenshot 2025-09-05 145619" src="https://github.com/user-attachments/assets/9a783aec-5434-4e01-a4f2-2bd61c824f83" />

After : 
<img width="1878" height="836" alt="Screenshot 2025-09-05 145700" src="https://github.com/user-attachments/assets/94cf935f-fd23-424a-b755-40806cc6302f" />
