### PR TITLE
About us link fixed

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
         <ul class="navbar-nav ms-auto">
           <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
           <li class="nav-item"><a class="nav-link" href="#featured-car">Explore cars</a></li>
-          <li class="nav-item"><a class="nav-link" href="./src/pages/about.html">About us</a></li>
+          <li class="nav-item"><a class="nav-link" href="./src/pages/about.html" >About us</a></li>
           <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
           <li class="nav-item"><a class="nav-link" href="ContactUs.html">Contact Us</a></li>
           <li class="nav-item"><a class="nav-link" href="offline.html">Offline Centers</a></li>


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #555 .

## Rationale for this change
  The about us link was not redirecting to the about page.

## What changes are included in this PR?
1. Fixed the broken link like the route was not perfectly written due to which it doesn't redirect.
2. Changed the line where the href for the about us was written.

## Are these changes tested?
Yes 
1. Manually tested locally using vercel dev.
3. Verified that clicking About Us in the navbar redirecting correctly to the About Us section.

## Are there any user-facing changes?
Yes 
1. Before: Clicking About Us in the navbar did not redirect to the section (only showed # in the URL).
2. After: Clicking About Us now redirects smoothly to the About Us section.