### PR TITLE
Ensure uniform height for blog boxes in blog section

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
     .blog-list::-webkit-scrollbar-thumb{ background: rgba(0,0,0,.15); border-radius:999px; }
     .blog-card{
       flex: 0 0 310px;
-      
+      width:200px;
       height: 400px;
       scroll-snap-align:start;
       background: var(--vehigo-card); border:1px solid var(--vehigo-border); border-radius: var(--radius-lg);


### PR DESCRIPTION
Description
UNDER GSSOC25
#580 
The blog boxes currently have varying heights depending on the content length, which disrupts the design consistency of the page. This PR standardizes the height of all blog boxes, ensuring a clean and uniform layout.

Related Issue
Uneven blog box heights causing layout inconsistency.

Changes Made
Applied consistent height styling across all blog boxes.
Used CSS (min-height with flexbox/grid alignment) to maintain uniform sizing.
Verified responsiveness to ensure proper scaling across devices.

Steps to Reproduce (Before Fix)
Navigate to the blog section.
Notice that blog boxes with shorter content have smaller heights compared to those with longer content.

Expected Behavior (After Fix)
All blog boxes have consistent height and width, regardless of content length.
The blog section layout appears visually balanced and professional.

Screenshots





<img width="1838" height="822" alt="image" src="https://github.com/user-attachments/assets/3b7e4467-bc9b-4d24-a033-bf041f5756f4" />


