### PR TITLE
Enhanced hover effects for get-start-card in both the modes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,3 @@
-
 :root {
   /**
   * colors
@@ -961,6 +960,17 @@ body.dark-theme.get-start-card {
 .get-start-card:hover {
   background: var(--alice-blue-2);
   box-shadow: var(--shadow-1);
+  transform: translateY(-4px) scale(1.03);
+  border-color: var(--carolina-blue);
+  transition: box-shadow 0.3s, transform 0.3s, border-color 0.3s;
+}
+
+body.dark-mode .get-start-card:hover {
+  background: #222831;
+  box-shadow: 0 8px 24px rgba(52, 152, 219, 0.25);
+  border-color: #4e7fb4;
+  transform: translateY(-4px) scale(1.03);
+  transition: box-shadow 0.3s, transform 0.3s, border-color 0.3s;
 }
 
 .get-start-card .card-icon {

--- a/index.html
+++ b/index.html
@@ -246,7 +246,8 @@
       padding:18px; height:100%; box-shadow: var(--shadow-1);
       transition: transform .2s ease, box-shadow .25s ease, border-color .2s ease;
     }
-    .get-start-card:hover{ transform: translateY(-6px); box-shadow: var(--shadow-2); border-color: rgba(37,99,235,.25); }
+    .get-start-card:hover{ transform: translateY(-8px) scale(1.03); box-shadow: 0 8px 32px rgba(37,99,235,0.13); border-color: var(--vehigo-primary); background: linear-gradient(180deg, #f6f8fa 80%, #e5e7eb 100%); transition: box-shadow 0.3s, transform 0.3s, border-color 0.3s, background 0.3s; }
+    .dark-theme .get-start-card:hover { transform: translateY(-8px) scale(1.03); box-shadow: 0 8px 32px rgba(37,99,235,0.22); border-color: var(--vehigo-primary-2); background: linear-gradient(180deg, #101927 80%, #1f2a3a 100%); transition: box-shadow 0.3s, transform 0.3s, border-color 0.3s, background 0.3s; }
     .get-start-card .card-icon{
       width:44px; height:44px; display:grid; place-items:center; border-radius:12px; margin-bottom:10px;
       background: linear-gradient(180deg, rgba(37,99,235,.12), rgba(37,99,235,.06));
@@ -766,7 +767,7 @@
             <p>Secure payments, verified profiles, and clear policies — effortless.</p>
           </div>
         </li>
-      </ul>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #550 

## Rationale for this change

The **Get-Start Card** had minimal hover effects across light and dark modes, which reduced visual feedback and user experience.  
Enhancing hover effects improves **interactivity, accessibility, and overall design consistency**.

## What changes are included in this PR?

- Added **improved hover styles** for the Get-Start Card in both light and dark modes.  
- Ensured consistent transition effects for smoother user interaction.  
- Updated CSS to maintain design uniformity across themes.

## Are these changes tested?

Yes.  
- Verified locally that hover effects now work consistently in **both light and dark modes**.  

## Are there any user-facing changes?

Yes.  
- Users will now experience **enhanced hover effects** when interacting with the Get-Start Card, making the UI more intuitive and visually engaging. 