### PR TITLE
correct the font colour of help centre section

### DIFF
--- a/src/pages/help-center.html
+++ b/src/pages/help-center.html
@@ -72,10 +72,13 @@
 
         /* Support */
         .contact-support { background: linear-gradient(180deg, #f8fafc, #eef2ff); padding: 54px 0; }
+        .contact-support h2 { color: #000000; text-align: center; margin-bottom: 10px; }
+        .contact-support p { color: #000000; text-align: center; margin-bottom: 30px; }
         .support-options { display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:18px; }
         .support-card { background:#ffffff; border:1px solid #e5e7eb; border-radius:16px; padding:18px; text-align:center; box-shadow:0 8px 16px rgba(0,0,0,.06); }
         .support-card i { color:#2563eb; font-size:26px; margin-bottom:8px; }
-        .support-card h3 { margin:6px 0 4px; }
+        .support-card h3 { margin:6px 0 4px; color: #000000; }
+        .support-card p { color: #333333; }
 
         @media (max-width: 640px) { .help-hero h1 { font-size: 2.1rem; } }
 


### PR DESCRIPTION
issue=font colour of word in help centre section same as background colour

solution=i changed it to black font so that it visible clearly

corresponding issue= #600

<img width="1919" height="1018" alt="Screenshot 2025-09-10 234542" src="https://github.com/user-attachments/assets/e2f36336-6b08-4930-b0e5-68fbd607c0f6" />
before

<img width="1919" height="1079" alt="Screenshot 2025-09-10 235109" src="https://github.com/user-attachments/assets/39c839b5-f321-422b-b0e6-99ab880464ac" />
after 

so review changes and assign this issue to me and give level 3 @Akashshelke07 
