### PR TITLE
Change font colour of text which is not visible in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -955,6 +955,11 @@
       filter: none;
     }
 
+    /* Light theme: improve visibility of hero location badge text */
+    body:not(.dark-theme) .hero .badge {
+      color: #000;
+    }
+
     body:not(.dark-theme) .footer-column h6 {
       color: var(--vehigo-text);
     }


### PR DESCRIPTION
Issue=font colour of text not visible in light mode

Solution= i changed it and now it is visible clearly

Corresponding issue= #667 

<img width="1919" height="969" alt="Screenshot 2025-09-16 191141" src="https://github.com/user-attachments/assets/1ee7f8f3-8abd-47db-8935-afefb80376e4" />
before 


<img width="1908" height="968" alt="Screenshot 2025-09-16 191404" src="https://github.com/user-attachments/assets/39712054-29c2-4b0d-806a-3f7129912219" />
after 

so review changes and assign this issue to me and give level 3 or 2 @Akashshelke07 