### PR TITLE
Made the blog.html link working in bill.html

### DIFF
--- a/src/pages/bill.html
+++ b/src/pages/bill.html
@@ -211,7 +211,7 @@
           </li>
 
           <li>
-            <a href="#blog" class="navbar-link" data-nav-link>Blog</a>
+            <a href="../../blog.html" class="navbar-link" data-nav-link>Blog</a>
           </li>
 
         </ul>
@@ -411,7 +411,7 @@
     <div class="container">
       <div class="footer-top">
         <div class="footer-brand">
-          <a href="#" class="logo">
+          <a href="../../index.html" class="logo">
             <img src="../assets/images/vehigologo.png" alt="VehiGo logo" />
           </a>
           <p class="footer-text">
@@ -444,7 +444,7 @@
         </ul>
         <p class="copyright">
 
-          &copy; 2024 <a href="#">VehiGo</a>. All Rights Reserved.
+          &copy; 2025 <a href="../../index.html">VehiGo</a>. All Rights Reserved.
 
 
         </p>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #783 

## Rationale for this change

The header navigation link to blog.html on the bill.html page was broken, preventing users from accessing the blog. Fixing this improves navigation consistency and user experience.

## What changes are included in this PR?

Corrected the href path in the bill.html header so that the Blog link properly redirects to blog.html.

## Are these changes tested?

Yes, tested locally by opening bill.html in the browser and confirming the Blog link redirects to blog.html.

## Are there any user-facing changes?

Yes, users can now successfully navigate to the Blog page from the header on bill.html.