### PR TITLE
[BUG FIX]solved social media icons in explore cars page

### DIFF
--- a/featured-car.html
+++ b/featured-car.html
@@ -10,8 +10,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet"/>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"/>
-  <script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+<script type="module" src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"></script>
   <script nomodule src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"></script>
 
   <style>
@@ -241,6 +241,11 @@
       transform: translateY(-2px);
       box-shadow: 0 8px 25px rgba(124, 58, 237, 0.3);
     }
+    .social-links i {
+  font-size: 22px;   /* controls size of icon */
+  color: var(--text); /* ensures visibility on background */
+}
+
 
     .contact-info {
       background: var(--card-2);
@@ -1172,18 +1177,18 @@
             <div class="social-links">
               <a href="https://www.linkedin.com" target="_blank" class="social-link floating-icon"
                 aria-label="LinkedIn">
-                <i class="fab fa-linkedin"></i>
+                <i class="fa-brands fa-linkedin"></i>
               </a>
               <a href="https://www.twitter.com" target="_blank" class="social-link floating-icon" aria-label="Twitter">
-                <i class="fab fa-x-twitter"></i>
+                <i class="fa-brands fa-twitter"></i>
               </a>
               <a href="https://www.instagram.com" target="_blank" class="social-link floating-icon"
                 aria-label="Instagram">
-                <i class="fab fa-instagram"></i>
+                <i class="fa-brands fa-instagram"></i>
               </a>
               <a href="https://www.facebook.com" target="_blank" class="social-link floating-icon"
                 aria-label="Facebook">
-                <i class="fab fa-facebook"></i>
+                 <i class="fa-brands fa-facebook"></i>
               </a>
             </div>
           </div>


### PR DESCRIPTION
This pull request resolves the issue where social media icons (LinkedIn, Instagram, Facebook) were not visible in the footer section.
The problem was caused by an outdated Font Awesome version (4.7), which does not include the newer icon classes used in the footer. Additionally, CSS styling for the icons needed slight adjustments to ensure proper visibility and alignment.

Updated Font Awesome library:
Replaced version 4.7 with Font Awesome 6.4, which includes all the necessary brand icons.
This allows the icons to render correctly and ensures compatibility with modern icon classes.

https://github.com/user-attachments/assets/d0a246d4-55ba-4ffa-9a32-db990f8fd0a9

