### PR TITLE
 [Bug Fix] Fixed inverted theme toggler labels

### DIFF
--- a/ContactUs.html
+++ b/ContactUs.html
@@ -81,7 +81,7 @@
 
           <li class="nav-item">
             <button id="themeToggle" class="btn btn-outline-secondary theme-toggle-btn" type="button">
-              <i class="fa-solid fa-gear"></i><span class="label">Light</span>
+              <i class="fa-solid fa-gear"></i><span class="label">Dark</span>
             </button>
           </li>
 
@@ -229,11 +229,11 @@ themeToggleBtn.addEventListener('click', () => {
   if(document.body.classList.contains('dark-mode')){
     themeToggleBtn.classList.remove('light');
     themeToggleBtn.classList.add('dark');
-    themeToggleBtn.querySelector('.label').textContent = 'Dark';
+    themeToggleBtn.querySelector('.label').textContent = 'Light';
   } else {
     themeToggleBtn.classList.remove('dark');
     themeToggleBtn.classList.add('light');
-    themeToggleBtn.querySelector('.label').textContent = 'Light';
+    themeToggleBtn.querySelector('.label').textContent = 'Dark';
   }
 });
 </script>


### PR DESCRIPTION
## Which issue does this PR close?

Closes #846 
<!-- Replace <issue-number> with the actual issue ID once you raise the bug issue (e.g., #45) -->

## Rationale for this change

The theme toggler button labels were inverted:
- Clicking on **Dark** applied **Light theme**
- Clicking on **Light** applied **Dark theme**

This was confusing for users as the button text did not match the theme action.  
This PR fixes the toggler so that the button label always represents the **next available theme**.

## What changes are included in this PR?

- Updated the theme toggle logic in JavaScript.
- Ensured that when the site is in Light mode, the button shows **Dark**, and vice versa.
- Verified consistency of the toggle button across pages.

## Are these changes tested?

-Tested manually in the browser for both Light and Dark themes.
-Verified switching works correctly across multiple toggles.

## Are there any user-facing changes?

- Yes, the **theme toggle button now works correctly**:
  - Shows the correct label.
  - Provides a consistent user experience.
  
**Screenshots (Before vs After):**

_Before (buggy):_
<img width="1870" height="967" alt="Screenshot 2025-10-02 150455" src="https://github.com/user-attachments/assets/ee8507bb-3ecc-4339-ac34-494c3cb979f3" />

_After (fixed):_
<img width="1853" height="959" alt="image" src="https://github.com/user-attachments/assets/696d90b4-0491-4277-889b-5f66ccadc678" />

