### PR TITLE
changed redirect error in homapage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1783,7 +1783,7 @@
           <a href="./privacypolicy.html">Privacy</a>
           <a href="./tandc.html">Terms</a>
           <a href="./src/pages/help-center.html">Support</a>
-          <a href="./                     sitemap.html">Sitemap</a>
+          <a href="./sitemap.html">Sitemap</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Issue=sitemap not redirect correctly in homepage

Solution= i changes it and now redirect correctly

https://github.com/user-attachments/assets/0e775c6a-55ce-4e4a-9f2a-00c4b48a198d
before 

https://github.com/user-attachments/assets/69848679-58db-4343-8dd8-5ddfd0c36fd6
after

so find issue and corresponding changes and assign this pr to me and give level 3 or 2 @Akashshelke07 

