### PR TITLE
Made the footer text visible in dark mode

### DIFF
--- a/sitemap.html
+++ b/sitemap.html
@@ -424,6 +424,43 @@
                 text-align: center;
             }
         }
+        .footer {
+            background: var(--vehigo-text);
+            color: #ffffff;
+            padding: 3rem 0 2rem;
+            margin-top: 3rem;
+            transition: background-color 0.3s ease;
+        }
+
+        /* Dark theme footer styles */
+        .dark-theme .footer {
+            background: var(--vehigo-bg-light);
+            border-top: 1px solid var(--vehigo-border);
+        }
+
+        .dark-theme .footer-bottom {
+            border-top-color: var(--vehigo-border);
+        }
+
+        .dark-theme .footer-link {
+            color: #94a3b8;
+        }
+
+        .dark-theme .footer-link:hover {
+            color: var(--vehigo-accent);
+        }
+
+        .dark-theme .footer-text {
+            color: #94a3b8;
+        }
+
+        .dark-theme .social-link {
+            color: #94a3b8;
+        }
+
+        .dark-theme .social-link:hover {
+            color: var(--vehigo-accent);
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #834 

## Rationale for this change

On the sitemap.html page, the footer text was not visible in dark mode, which reduced readability and created inconsistency compared to other pages where footer text adapts correctly. This change ensures consistent and accessible footer styling across all modes.

## What changes are included in this PR?

- Fixed footer text styling on sitemap.html to ensure visibility in dark mode.
- Aligned footer styles with the rest of the site for consistent appearance.

## Are these changes tested?

Manually tested in light mode and dark mode to confirm footer text adapts correctly.

## Are there any user-facing changes?

Yes. Users can now clearly read the footer text in dark mode on the sitemap.html page, improving consistency and accessibility.