### PR TITLE
Update Rent Car page footer social links to company profiles #866

### DIFF
--- a/rentcar.html
+++ b/rentcar.html
@@ -845,10 +845,11 @@
         <div class="footer-col">
           <h6>Follow</h6>
           <div class="socials">
-            <a href="https://www.linkedin.com" target="_blank"><i class="fab fa-linkedin"></i></a>
-            <a href="https://www.twitter.com" target="_blank"><i class="fab fa-x-twitter"></i></a>
-            <a href="https://www.instagram.com" target="_blank"><i class="fab fa-instagram"></i></a>
-            <a href="https://www.facebook.com" target="_blank"><i class="fab fa-facebook"></i></a>
+            <a href="https://www.facebook.com/vehigo" target="_blank"><i class="fab fa-facebook"></i></a>
+            <a href="https://www.instagram.com/vehigo" target="_blank"><i class="fab fa-instagram"></i></a>
+            <a href="https://x.com/vehigo" target="_blank"><i class="fab fa-x-twitter"></i></a>
+            <a href="https://www.linkedin.com/company/vehigo" target="_blank"><i class="fab fa-linkedin"></i></a>
+            <a href="https://github.com/vehigo" target="_blank"><i class="fab fa-github"></i></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #866

## Rationale for this change

This change fixes the footer social media links on the Rent Car page to redirect to Vehigo's official company profiles instead of generic social media homepages. This provides a more professional user experience and ensures users are directed to the correct company accounts across all social media platforms.

## What changes are included in this PR?

### Files Modified:
- **`rentcar.html`**: Updated footer social media links to point to Vehigo company profiles

### Changes Made:
- **Facebook**: Updated from `https://www.facebook.com` to `https://www.facebook.com/vehigo`
- **Instagram**: Updated from `https://www.instagram.com` to `https://www.instagram.com/vehigo`
- **X (Twitter)**: Updated from `https://www.twitter.com` to `https://x.com/vehigo`
- **LinkedIn**: Updated from `https://www.linkedin.com` to `https://www.linkedin.com/company/vehigo`
- **GitHub**: Added missing link `https://github.com/vehigo`

All links maintain `target="_blank"` for proper UX, and existing styling/hover effects remain consistent.

## Are these changes tested?

The changes have been manually verified by:
1. ✅ Checking that all social media links now point to Vehigo company profiles
2. ✅ Confirming all links open in new tabs (`target="_blank"`)
3. ✅ Verifying existing CSS styling and hover effects are preserved
4. ✅ Testing responsive design across different screen sizes

## Are there any user-facing changes?

Yes, this PR introduces user-facing changes to the footer social media section:
- Users will now be directed to Vehigo's official social media profiles instead of generic platform homepages
- Added GitHub link for better developer engagement
- All links maintain the same visual appearance and behavior as before

---

*Ready for review and merge! 🔗✨*
