### PR TITLE
Contact Us page footer social links redirect to generic pages instead of company profiles 

### DIFF
--- a/ContactUs.css
+++ b/ContactUs.css
@@ -346,6 +346,18 @@ body.dark .footer-link:hover,
 body.dark .social-link:hover {
   color: #60a5fa;
 }
+/* Dark Mode Logo Fix for Navbar & Footer */
+body.dark-mode .navbar-brand img,
+body.dark-mode .footer-brand img {
+  filter: brightness(0) invert(1);
+  transition: filter 0.3s ease;
+  background-color: transparent; /* remove any background */
+}
+
+body.dark-mode .navbar-brand:hover img,
+body.dark-mode .footer-brand:hover img {
+  opacity: 0.8;
+}
 
 .footer a {
   color: inherit;

--- a/ContactUs.html
+++ b/ContactUs.html
@@ -195,20 +195,46 @@
     </div>
 
     <!-- Bottom Section -->
-    <div class="footer-bottom">
-      <ul class="social-list">
-        <li><a href="https://www.facebook.com/" class="social-link" aria-label="Facebook"><ion-icon name="logo-facebook"></ion-icon></a></li>
-        <li><a href="https://www.instagram.com/" class="social-link" aria-label="Instagram"><ion-icon name="logo-instagram"></ion-icon></a></li>
-        <li><a href="https://x.com/" class="social-link" aria-label="X (Twitter)"><ion-icon name="logo-twitter"></ion-icon></a></li>
-        <li><a href="https://www.linkedin.com/feed/" class="social-link" aria-label="LinkedIn"><ion-icon name="logo-linkedin"></ion-icon></a></li>
-        <li><a href="#" class="social-link" aria-label="GitHub"><ion-icon name="logo-github"></ion-icon></a></li>
-        <li><a href="https://mail.google.com/" class="social-link" aria-label="Email"><ion-icon name="mail-outline"></ion-icon></a></li>
-      </ul>
+    <!-- Bottom Section -->
+<div class="footer-bottom">
+  <ul class="social-list">
+    <li>
+      <a href="https://facebook.com/vehigo" class="social-link" aria-label="Facebook" target="_blank" rel="noopener noreferrer">
+        <ion-icon name="logo-facebook"></ion-icon>
+      </a>
+    </li>
+    <li>
+      <a href="https://instagram.com/vehigo" class="social-link" aria-label="Instagram" target="_blank" rel="noopener noreferrer">
+        <ion-icon name="logo-instagram"></ion-icon>
+      </a>
+    </li>
+    <li>
+      <a href="https://twitter.com/vehigo" class="social-link" aria-label="X (Twitter)" target="_blank" rel="noopener noreferrer">
+        <ion-icon name="logo-twitter"></ion-icon>
+      </a>
+    </li>
+    <li>
+      <a href="https://linkedin.com/company/vehigo" class="social-link" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
+        <ion-icon name="logo-linkedin"></ion-icon>
+      </a>
+    </li>
+    <li>
+      <a href="https://github.com/vehigo" class="social-link" aria-label="GitHub" target="_blank" rel="noopener noreferrer">
+        <ion-icon name="logo-github"></ion-icon>
+      </a>
+    </li>
+    <li>
+      <a href="mailto:contact@vehigo.com" class="social-link" aria-label="Email">
+        <ion-icon name="mail-outline"></ion-icon>
+      </a>
+    </li>
+  </ul>
 
-      <p class="copyright">
-        &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> | All rights reserved
-      </p>
-    </div>
+  <p class="copyright">
+    &copy; <span id="copyright-year"></span> <a href="#">VehiGo</a> | All rights reserved
+  </p>
+</div>
+
   </div>
 </footer>
 


### PR DESCRIPTION
#864 fixed

- Updated all social media icons in the footer to point to the company’s official profiles.
- Added target="_blank" for opening links in a new tab.
- Verified styling and hover effects remain consistent.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dab4295e-0536-4e8b-88e5-66f71ef7cb74" />

