### PR TITLE
Fixed Header Link for Home on offline.html

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -541,7 +541,7 @@ body.dark-theme #searchInput:focus::placeholder {
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
               <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                 <li class="nav-item">
-                  <a class="nav-link active" href="/src/index.html">Home</a>
+                  <a class="nav-link active" href="index.html">Home</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="featured-car.html">Explore Cars</a>


### PR DESCRIPTION


## Which issue does this PR close?
- Closes #911 

## Rationale for this change
The header on the `offline.html` page had visibility issues, and some links were not correctly configured.  
While most of the header styling and structure were already fixed by a previous contributor, the **Home link** was still incorrect and needed to be properly linked to the main landing page.

## What changes are included in this PR
- Corrected the **Home** link in the `offline.html` header to point to `index.html`.
- Verified that all other navigation links are consistent with the main site’s header.
- Maintained styling consistency for visibility and readability.

## Are these changes tested?
- Yes, the updated Home link was tested in the browser.
- Navigation now redirects correctly to the homepage.
- Header links remain clearly visible and accessible.

## Are there any user-facing changes?
- Users can now navigate back to the homepage directly from the `offline.html` page header.
- Improved navigation consistency across pages.

## Screenshots
<img width="1895" height="157" alt="image" src="https://github.com/user-attachments/assets/19980aef-aff8-4786-896d-659c47ed7687" />
