### PR TITLE
fixed duplicate back to top icons

### DIFF
--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -132,9 +132,6 @@
       background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%) !important;
     }
 
-
-
-
     /* Dark theme coverage for About page */
     .dark-theme { background-color: #0f0f14; color: #e5e7eb; }
     .dark-theme h1, .dark-theme h2, .dark-theme h3, .dark-theme h4, .dark-theme h5, .dark-theme h6 { color: #ffffff; }
@@ -150,7 +147,7 @@
     .dark-theme .card-icon { color: #93c5fd; }
 
     /* Buttons */
-    .btn { background: #2563eb; color: #fff; border-radius: 9999px; padding: 10px 18px; border: none; }
+     .btn { background: #2563eb; color: #fff; border-radius: 9999px; padding: 10px 18px; border: none; }
     .btn:hover { background: #1e40af; }
     .dark-theme .btn { background: #3b82f6; }
 
@@ -682,27 +679,6 @@
       </div>
     </footer>
   </div>
-
-  <!-- Scroll to Top Button -->
-  <a href="./about.html" style="
-    position: fixed;
-    bottom: 30px;
-    left: 30px;
-    background-color: #007BFF;
-    color: white;
-    border-radius: 50%;
-    width: 50px;
-    height: 50px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-decoration: none;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-    z-index: 999;
-    transition: background-color 0.3s;
-  " onmouseover="this.style.backgroundColor='#0056b3'" onmouseout="this.style.backgroundColor='#007BFF'">
-    <ion-icon name="chevron-up-outline" style="font-size: 24px;"></ion-icon>
-  </a>
 
   <!-- Scroll Buttons -->
   <button id="scrollTopBtn" style="


### PR DESCRIPTION
## Which issue does this PR close?


- Closes #953.

## Rationale for this change

There were two “Back to Top” icons appearing on certain pages, leading to a cluttered UI and confusing user experience.
This PR removes the duplicate icon and ensures only one properly positioned “Back to Top” button is visible.


## What changes are included in this PR?

Removed the redundant "Back to Top" icon element from affected pages.
Verified proper alignment and functionality of the remaining icon.
Ensured consistent styling across all pages.


## Are these changes tested?

Yes 

Visually tested on all pages where the icon appears.
Confirmed only one icon is displayed and scrolls smoothly to the top when clicked.

## Are there any user-facing changes?
 
Yes — users will now see only one clean and functional “Back to Top” icon, improving overall UI consistency.


<img width="1339" height="679" alt="image" src="https://github.com/user-attachments/assets/803c5bfa-c1fb-49d6-9d13-131a6d7de97c" />
 
 before there was back to top icon on left side now it was removed for clear understanding 