### PR TITLE
Support as well as sitemap link added in about footer

### DIFF
--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -677,6 +677,10 @@
             <a href="../../privacypolicy.html">Privacy</a>
             <a href="tandc.html">Terms</a>
             <a href="../../ContactUs.html">Contact</a>
+                        <a href="help-center.html">Support</a>
+                                                <a href="../../sitemap.html">Sitemap</a>
+
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #930 
## Rationale for this change
The footer on the `about.html` page was missing the **Support** link and had an inconsistent **Sitemap** link compared to other pages.  
This prevented users from easily accessing support and caused inconsistencies in navigation across the website.  
Adding the Support link and correcting the Sitemap link improves usability and maintains a consistent footer design.

## What changes are included in this PR?
- Added **Support** link to the footer on `about.html`  
- Corrected the **Sitemap** link to point to the correct page  
- Ensured styling and spacing are consistent with other footer links

## Are these changes tested?
- Opened `about.html` in a browser and confirmed the **Support** link appears  
- Verified that clicking the **Support** and **Sitemap** links navigates to the correct pages  
- Checked footer design to ensure consistency with other pages

## Are there any user-facing changes?
- Users can now directly access the Support page from the footer  
- Sitemap link navigates correctly  
- Footer now matches other pages visually and functionally

## Screenshots (optional)

### Before Fix
<img width="1901" height="446" alt="image" src="https://github.com/user-attachments/assets/a94bcc44-32a8-4d03-851c-8b04a5efcdbf" />

### After Fix
<img width="1894" height="441" alt="image" src="https://github.com/user-attachments/assets/916fcc2c-c797-49d9-b991-759d4244ed3d" />
