### PR TITLE
[FIX]Fixed the dark mode styling in Rent your car

### DIFF
--- a/rentcar.html
+++ b/rentcar.html
@@ -670,6 +670,61 @@
         font-size: 16px;
       }
     }
+
+    /* Dark Theme */
+body.dark-mode,
+body.dark-theme {
+  background: linear-gradient(135deg, #1a1a2e, #16213e);
+  color: #f1f5f9;
+}
+
+body.dark-mode .vehicle-form-section,
+body.dark-theme .vehicle-form-section {
+  background: linear-gradient(135deg, #1a1a2e, #16213e);
+}
+
+body.dark-mode .vehicle-form-card,
+body.dark-theme .vehicle-form-card {
+  background-color: #1e293b;
+  color: #f1f5f9;
+  border: 1px solid #334155;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+body.dark-mode .vehicle-form-title,
+body.dark-theme .vehicle-form-title {
+  color: #f1f5f9;
+}
+
+body.dark-mode .vehicle-input-group label,
+body.dark-theme .vehicle-input-group label {
+  color: #e2e8f0;
+}
+
+body.dark-mode .vehicle-input-group input,
+body.dark-theme .vehicle-input-group input {
+  background-color: #1e293b;
+  border: 1px solid #475569;
+  color: #f1f5f9;
+}
+
+body.dark-mode .vehicle-input-group input:focus,
+body.dark-theme .vehicle-input-group input:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+body.dark-mode .vehicle-submit-btn,
+body.dark-theme .vehicle-submit-btn {
+  background-color: #2563eb;
+  color: #ffffff;
+}
+
+body.dark-mode .vehicle-submit-btn:hover,
+body.dark-theme .vehicle-submit-btn:hover {
+  background-color: #1d4ed8;
+}
+
     
     @media (max-width: 480px) {
       h1 {


### PR DESCRIPTION
Which issue does this PR close?
Closes #988 

Rationale for this change
The dark mode styling in the Rent Your Car section was inconsistent — certain elements (like form backgrounds, text, and input fields) were not adapting correctly when switching to dark mode. This update ensures a visually consistent experience across both light and dark themes.

What changes are included in this PR?
Added proper dark theme overrides for .vehicle-form-section, .vehicle-form-card, and related elements.
Ensured text, inputs, labels, and buttons adapt to dark mode.
Improved contrast and readability in dark mode.
Matched dark mode colors with the existing Vehigo blue color palette for consistency.
<img width="1885" height="891" alt="image" src="https://github.com/user-attachments/assets/9ee67e46-6197-4ae5-b494-9761f984447a" />


Are these changes tested?
Yes.
Verified visually in both light and dark modes.
Tested transitions between modes to confirm smooth color updates.
Ensured no layout or spacing regressions in the Rent Your Car form.

Are there any user-facing changes?
Yes.
Users can now toggle between light and dark modes and see consistent theming applied in the Rent Your Car form.
Improved accessibility and readability in dark mode.