### PR TITLE
[FIX] Fixed the multiple upward arrow

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1966,25 +1966,6 @@ body.dark-theme .section-sub {
     }
   });
 </script>
-<a href="./index.html" style="
-  position: fixed;
-  bottom: 30px;
-  left: 30px;
-  background-color: #007BFF;
-  color: white;
-  border-radius: 50%;
-  width: 50px;
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  z-index: 999;
-  transition: background-color 0.3s;
-" onmouseover="this.style.backgroundColor='#0056b3'" onmouseout="this.style.backgroundColor='#007BFF'">
-  <ion-icon name="chevron-up-outline" style="font-size: 24px;"></ion-icon>
-</a>
 
     <!-- Scroll Buttons -->
 <button id="scrollTopBtn" style="
@@ -2074,7 +2055,7 @@ body.dark-theme .section-sub {
 </script>
 
 
-<button id="scrollTop" style="position:fixed;bottom:20px;right:20px;display:none;width:50px;height:50px;border:none;border-radius:50%;background:#007bff;color:#fff;font-size:24px;cursor:pointer;box-shadow:0 4px 6px rgba(0,0,0,0.3);transition:0.3s;">⬆</button>
+
 
 <script>
 const btn = document.getElementById('scrollTop');


### PR DESCRIPTION
Which issue does this PR close?
Closes #993 

Rationale for this change
There were two “scroll-to-top” buttons (#scrollTopBtn and #scrollTop) present in the HTML, which caused duplicate upward arrows to appear on the webpage. This created a visual redundancy and potential confusion for users.

What changes are included in this PR?
Removed the duplicate #scrollTop button from the HTML file.
Retained only the #scrollTopBtn button for the scroll-to-top functionality.
Verified that styling and positioning remain consistent with the existing scrollBottomBtn.
<img width="1898" height="897" alt="image" src="https://github.com/user-attachments/assets/05ff7dd4-18af-4f67-ae9a-adcbd2055089" />
<img width="1901" height="901" alt="image" src="https://github.com/user-attachments/assets/2744f99c-1728-4963-9d14-b6bf0cd88c64" />
<img width="1902" height="888" alt="image" src="https://github.com/user-attachments/assets/15b9d2e6-7eea-4feb-a3f6-ac0ad3440dbd" />


Are these changes tested?
✅ Yes, tested locally.
Verified that only one upward arrow is now displayed.
Scroll-to-top functionality continues to work correctly.

Are there any user-facing changes?
Yes, users will now see only a single upward arrow (scroll-to-top button) instead of two, improving the UI clarity and visual consistency.